### PR TITLE
Compose: refactor main screen state

### DIFF
--- a/app/src/main/java/fobo66/exchangecourcesbelarus/entities/MainScreenState.kt
+++ b/app/src/main/java/fobo66/exchangecourcesbelarus/entities/MainScreenState.kt
@@ -1,13 +1,14 @@
 package fobo66.exchangecourcesbelarus.entities
 
 import androidx.compose.runtime.Stable
-import fobo66.valiutchik.core.entities.BestCurrencyRate
 
 sealed class MainScreenState(val isInProgress: Boolean = true) {
   @Stable
-  object Loading: MainScreenState()
+  object Loading : MainScreenState()
+
   @Stable
-  data class LoadedRates(val bestCurrencyRates: List<BestCurrencyRate>) : MainScreenState(false)
+  object LoadedRates : MainScreenState(false)
+
   @Stable
   object Error : MainScreenState(false)
 }

--- a/app/src/main/java/fobo66/exchangecourcesbelarus/ui/MainViewModel.kt
+++ b/app/src/main/java/fobo66/exchangecourcesbelarus/ui/MainViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import fobo66.exchangecourcesbelarus.entities.MainScreenState
 import fobo66.exchangecourcesbelarus.util.CurrencyRatesLoadFailedException
 import fobo66.valiutchik.core.entities.BestCurrencyRate
 import fobo66.valiutchik.core.usecases.CopyCurrencyRateToClipboard
@@ -17,6 +18,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -30,13 +33,19 @@ class MainViewModel @Inject constructor(
 
   val bestCurrencyRates: Flow<List<BestCurrencyRate>>
     get() = loadExchangeRates.execute()
+      .filter { it.isNotEmpty() }
+      .onEach {
+        _mainScreenState.emit(MainScreenState.LoadedRates)
+      }
 
   val errors: SharedFlow<Unit>
     get() = _errors
 
   private val _errors = MutableSharedFlow<Unit>()
   private val _progress = MutableStateFlow(false)
+  private val _mainScreenState = MutableStateFlow<MainScreenState>(MainScreenState.Loading)
   val progress = _progress.asStateFlow()
+  val mainScreenState = _mainScreenState.asStateFlow()
 
   fun findBankOnMap(bankName: CharSequence): Intent? {
     return findBankOnMap.execute(bankName)
@@ -47,9 +56,11 @@ class MainViewModel @Inject constructor(
       try {
         showProgress()
         refreshExchangeRates.execute(LocalDateTime.now())
+        _mainScreenState.emit(MainScreenState.LoadedRates)
       } catch (e: CurrencyRatesLoadFailedException) {
         Timber.e(e, "Error happened when refreshing currency rates")
         _errors.emit(Unit)
+        _mainScreenState.emit(MainScreenState.Error)
       } finally {
         hideProgress()
       }
@@ -61,6 +72,7 @@ class MainViewModel @Inject constructor(
 
   private suspend fun showProgress() {
     _progress.emit(true)
+    _mainScreenState.emit(MainScreenState.Loading)
   }
 
   suspend fun hideProgress() {

--- a/app/src/main/java/fobo66/exchangecourcesbelarus/ui/main/MainScreen.kt
+++ b/app/src/main/java/fobo66/exchangecourcesbelarus/ui/main/MainScreen.kt
@@ -109,10 +109,17 @@ fun BestCurrencyRateCard(
 
 @Composable
 fun MainScreenNoPermission(
-  textToShow: String,
+  shouldShowRationale: Boolean,
   onRequestPermission: () -> Unit,
   modifier: Modifier = Modifier
 ) {
+  val textToShow = stringResource(
+    id = if (shouldShowRationale) {
+      string.permission_description_rationale
+    } else {
+      string.permission_description
+    }
+  )
   Box(modifier = modifier) {
     Column(modifier = Modifier.align(Alignment.Center)) {
       Text(


### PR DESCRIPTION
Rethinking main screen state handling to align better with Compose. Might include some workarounds for existing code temporarily