### PR TITLE
Migrate to Koin

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
   kotlin("android") version libs.versions.kotlin apply false
   kotlin("kapt") version libs.versions.kotlin apply false
   alias(libs.plugins.licenses) apply false
+  alias(libs.plugins.ksp) apply false
   alias(di.plugins.plugin) apply false
   alias(androidx.plugins.benchmark) apply false
   alias(testing.plugins.junit) apply false

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -18,6 +18,10 @@ plugins {
   `kotlin-dsl`
 }
 
+kotlin {
+  jvmToolchain(11)
+}
+
 repositories {
   mavenCentral()
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -210,6 +210,10 @@ pluginManagement {
     google()
     mavenCentral()
   }
+
+  plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+  }
 }
 
 rootProject.name = "Valiutchik"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ dependencyResolutionManagement {
       version("moshi", "1.15.0")
       version("coroutines", "1.7.1")
       plugin("licenses", "com.jaredsburrows.license").version("0.9.2")
+      plugin("ksp", "com.google.devtools.ksp").version("1.8.21-1.0.11")
       library("material", "com.google.android.material:material:1.9.0")
       library("retrofit", "com.squareup.retrofit2:retrofit:2.9.0")
       library("leakcanary", "com.squareup.leakcanary:leakcanary-android:2.11")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -160,9 +160,13 @@ dependencyResolutionManagement {
 
     register("di") {
       version("hilt", "2.46.1")
+      version("koin", "1.2.0")
       plugin("plugin", "com.google.dagger.hilt.android").versionRef("hilt")
       library("core", "com.google.dagger", "hilt-android").versionRef("hilt")
+      library("koin.core", "io.insert-koin:koin-android:3.4.0")
+      library("koin.annotations", "io.insert-koin", "koin-annotations").versionRef("koin")
       library("compiler", "com.google.dagger", "hilt-android-compiler").versionRef("hilt")
+      library("koin.compiler", "io.insert-koin", "koin-ksp-compiler").versionRef("koin")
       library("navigation", "androidx.hilt:hilt-navigation-compose:1.0.0")
     }
 


### PR DESCRIPTION
App crashes JVM on my Linux machine due to kapt. The only thing that depends on kapt is Hilt, so we need to switch to something that does the same thing but without kapt. The only natural choice was koin. Although I can look into the Anvil