### PR TITLE
Migrated to kotlinx.datetime

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -141,6 +141,7 @@ dependencies {
   // kotlin
   implementation(libs.kotlinx.coroutines.android)
   implementation(libs.kotlinx.collections)
+  implementation(libs.kotlinx.datetime)
 
   // androidx
   implementation(libs.androidx.activity)

--- a/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/widget/CurrencyWidget.kt
+++ b/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/widget/CurrencyWidget.kt
@@ -39,16 +39,16 @@ import dagger.hilt.android.AndroidEntryPoint
 import fobo66.exchangecourcesbelarus.ui.theme.ValiutchikWidgetTheme
 import fobo66.valiutchik.domain.entities.BestCurrencyRate
 import fobo66.valiutchik.domain.usecases.LoadExchangeRates
-import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.map
+import kotlinx.datetime.Clock
 
 class CurrencyWidget(private val loadExchangeRates: LoadExchangeRates) : GlanceAppWidget() {
   override suspend fun provideGlance(context: Context, id: GlanceId) = provideContent {
-    val rates: ImmutableList<BestCurrencyRate> by loadExchangeRates.execute(LocalDateTime.now())
+    val rates: ImmutableList<BestCurrencyRate> by loadExchangeRates.execute(Clock.System.now())
       .map { it.toImmutableList() }
       .collectAsState(
         initial = persistentListOf()

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
   implementation(libs.kotlinx.serialization)
   ksp(libs.hilt.compiler)
   implementation(libs.kotlinx.coroutines.android)
+  implementation(libs.kotlinx.datetime)
   implementation(libs.room.runtime)
   implementation(libs.room.ktx)
   ksp(libs.room.compiler)

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/PersistenceDataSource.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/PersistenceDataSource.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 package fobo66.valiutchik.core.model.datasource
 
 import fobo66.valiutchik.core.entities.BestCourse
-import java.time.LocalDateTime
 import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Instant
 
 /**
  * Datasource for working with persistent database
@@ -32,5 +32,5 @@ interface PersistenceDataSource {
   /**
    * Read entries from the database
    */
-  fun readBestCourses(latestTimestamp: LocalDateTime): Flow<List<BestCourse>>
+  fun readBestCourses(latestTimestamp: Instant): Flow<List<BestCourse>>
 }

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/PersistenceDataSourceImpl.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/PersistenceDataSourceImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package fobo66.valiutchik.core.model.datasource
 
 import fobo66.valiutchik.core.db.CurrencyRatesDatabase
 import fobo66.valiutchik.core.entities.BestCourse
-import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Instant
 
 class PersistenceDataSourceImpl @Inject constructor(
   private val database: CurrencyRatesDatabase
@@ -30,6 +30,6 @@ class PersistenceDataSourceImpl @Inject constructor(
     database.currencyRatesDao().insertBestCurrencyRates(bestCourses)
   }
 
-  override fun readBestCourses(latestTimestamp: LocalDateTime): Flow<List<BestCourse>> =
+  override fun readBestCourses(latestTimestamp: Instant): Flow<List<BestCourse>> =
     database.currencyRatesDao().loadLatestBestCurrencyRates(latestTimestamp.toString())
 }

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/repository/CurrencyRateRepository.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/repository/CurrencyRateRepository.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 package fobo66.valiutchik.core.model.repository
 
 import fobo66.valiutchik.core.entities.BestCourse
-import java.time.LocalDateTime
 import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Instant
 
 /**
  * Repository to process exchange rates
@@ -28,10 +28,10 @@ interface CurrencyRateRepository {
   /**
    * Refresh exchange rates for the given city
    */
-  suspend fun refreshExchangeRates(city: String, now: LocalDateTime)
+  suspend fun refreshExchangeRates(city: String, now: Instant)
 
   /**
    * Load exchange rates from database or from network
    */
-  fun loadExchangeRates(latestTimestamp: LocalDateTime): Flow<List<BestCourse>>
+  fun loadExchangeRates(latestTimestamp: Instant): Flow<List<BestCourse>>
 }

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/repository/CurrencyRateRepositoryImpl.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/repository/CurrencyRateRepositoryImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,11 +29,11 @@ import fobo66.valiutchik.core.util.BankNameNormalizer
 import fobo66.valiutchik.core.util.resolveCurrencyBuyRate
 import fobo66.valiutchik.core.util.resolveCurrencySellRate
 import java.io.IOException
-import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Instant
 
 class CurrencyRateRepositoryImpl @Inject constructor(
   private val bestCourseDataSource: BestCourseDataSource,
@@ -43,7 +43,7 @@ class CurrencyRateRepositoryImpl @Inject constructor(
   @Io private val ioDispatcher: CoroutineDispatcher
 ) : CurrencyRateRepository {
 
-  override suspend fun refreshExchangeRates(city: String, now: LocalDateTime) =
+  override suspend fun refreshExchangeRates(city: String, now: Instant) =
     withContext(ioDispatcher) {
       val currencies = try {
         currencyRatesDataSource.loadExchangeRates(city)
@@ -56,7 +56,7 @@ class CurrencyRateRepositoryImpl @Inject constructor(
       persistenceDataSource.saveBestCourses(bestCourses)
     }
 
-  override fun loadExchangeRates(latestTimestamp: LocalDateTime): Flow<List<BestCourse>> =
+  override fun loadExchangeRates(latestTimestamp: Instant): Flow<List<BestCourse>> =
     persistenceDataSource.readBestCourses(latestTimestamp)
 
   private fun findBestCourses(

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/repository/CurrencyRatesTimestampRepository.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/repository/CurrencyRatesTimestampRepository.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 
 package fobo66.valiutchik.core.model.repository
 
-import java.time.LocalDateTime
 import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Instant
 
 /**
  * Repository to handle timestamps of currency rates refresh
  */
 interface CurrencyRatesTimestampRepository {
-  suspend fun isNeededToUpdateCurrencyRates(now: LocalDateTime, updateInterval: Float): Boolean
-  suspend fun saveTimestamp(now: LocalDateTime)
+  suspend fun isNeededToUpdateCurrencyRates(now: Instant, updateInterval: Float): Boolean
+  suspend fun saveTimestamp(now: Instant)
 
-  fun loadLatestTimestamp(now: LocalDateTime): Flow<LocalDateTime>
+  fun loadLatestTimestamp(now: Instant): Flow<Instant>
 }

--- a/data/src/test/kotlin/fobo66/valiutchik/core/fake/FakePersistenceDataSource.kt
+++ b/data/src/test/kotlin/fobo66/valiutchik/core/fake/FakePersistenceDataSource.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package fobo66.valiutchik.core.fake
 
 import fobo66.valiutchik.core.entities.BestCourse
 import fobo66.valiutchik.core.model.datasource.PersistenceDataSource
-import java.time.LocalDateTime
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.datetime.Instant
 
 class FakePersistenceDataSource : PersistenceDataSource {
   var isSaved = false
@@ -29,5 +29,5 @@ class FakePersistenceDataSource : PersistenceDataSource {
     isSaved = true
   }
 
-  override fun readBestCourses(latestTimestamp: LocalDateTime): Flow<List<BestCourse>> = emptyFlow()
+  override fun readBestCourses(latestTimestamp: Instant): Flow<List<BestCourse>> = emptyFlow()
 }

--- a/data/src/test/kotlin/fobo66/valiutchik/core/model/repository/CurrencyRateRepositoryTest.kt
+++ b/data/src/test/kotlin/fobo66/valiutchik/core/model/repository/CurrencyRateRepositoryTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,20 +21,16 @@ import fobo66.valiutchik.core.fake.FakeBestCourseDataSource
 import fobo66.valiutchik.core.fake.FakeCurrencyRatesDataSource
 import fobo66.valiutchik.core.fake.FakePersistenceDataSource
 import fobo66.valiutchik.core.util.BankNameNormalizer
-import java.time.LocalDateTime
 import java.util.concurrent.Executors
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-/**
- * (c) 2019 Andrey Mukamolov <fobo66@protonmail.com>
- * Created 11/30/19.
- */
 @ExperimentalCoroutinesApi
 class CurrencyRateRepositoryTest {
 
@@ -56,7 +52,7 @@ class CurrencyRateRepositoryTest {
     ioDispatcher.close()
   }
 
-  private val now = LocalDateTime.now()
+  private val now = Clock.System.now()
 
   @Test
   fun `load exchange rates`() {

--- a/data/src/test/kotlin/fobo66/valiutchik/core/model/repository/CurrencyRatesTimestampRepositoryImplTest.kt
+++ b/data/src/test/kotlin/fobo66/valiutchik/core/model/repository/CurrencyRatesTimestampRepositoryImplTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@
 package fobo66.valiutchik.core.model.repository
 
 import fobo66.valiutchik.core.fake.FakePreferenceDataSource
-import java.time.LocalDateTime
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -28,7 +30,7 @@ import org.junit.jupiter.api.Test
 class CurrencyRatesTimestampRepositoryImplTest {
 
   private val preferencesDataSource = FakePreferenceDataSource()
-  private val now = LocalDateTime.now()
+  private val now = Clock.System.now()
   private val currencyRatesTimestampRepository: CurrencyRatesTimestampRepository =
     CurrencyRatesTimestampRepositoryImpl(preferencesDataSource)
 
@@ -52,7 +54,7 @@ class CurrencyRatesTimestampRepositoryImplTest {
 
   @Test
   fun `timestamp is old - need to update`() {
-    preferencesDataSource.string = now.minusDays(1).toString()
+    preferencesDataSource.string = (now - 1.days).toString()
 
     runTest {
       assertTrue(currencyRatesTimestampRepository.isNeededToUpdateCurrencyRates(now, 3.0f))
@@ -61,7 +63,7 @@ class CurrencyRatesTimestampRepositoryImplTest {
 
   @Test
   fun `timestamp slightly in the past - no need to update`() {
-    preferencesDataSource.string = now.minusHours(1).toString()
+    preferencesDataSource.string = (now - 1.hours).toString()
 
     runTest {
       assertFalse(currencyRatesTimestampRepository.isNeededToUpdateCurrencyRates(now, 3.0f))
@@ -70,7 +72,7 @@ class CurrencyRatesTimestampRepositoryImplTest {
 
   @Test
   fun `timestamp on the limit - no need to update`() {
-    preferencesDataSource.string = now.minusHours(3).toString()
+    preferencesDataSource.string = (now - 3.hours).toString()
 
     runTest {
       assertFalse(currencyRatesTimestampRepository.isNeededToUpdateCurrencyRates(now, 3.0f))
@@ -79,7 +81,7 @@ class CurrencyRatesTimestampRepositoryImplTest {
 
   @Test
   fun `timestamp above customized limit - need to update`() {
-    preferencesDataSource.string = now.minusHours(3).toString()
+    preferencesDataSource.string = (now - 3.hours).toString()
 
     runTest {
       assertTrue(currencyRatesTimestampRepository.isNeededToUpdateCurrencyRates(now, 2.0f))
@@ -88,7 +90,7 @@ class CurrencyRatesTimestampRepositoryImplTest {
 
   @Test
   fun `timestamp in the future - no need to update`() {
-    preferencesDataSource.string = now.plusHours(1).toString()
+    preferencesDataSource.string = (now + 1.hours).toString()
 
     runTest {
       assertFalse(currencyRatesTimestampRepository.isNeededToUpdateCurrencyRates(now, 3.0f))

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
   api(project(":data"))
   implementation(libs.androidx.annotation)
   implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.datetime)
   implementation(libs.hilt.core)
   ksp(libs.hilt.compiler)
   implementation(libs.timber)

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/CurrencyRatesInteractorImpl.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/CurrencyRatesInteractorImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 package fobo66.valiutchik.domain.usecases
 
 import fobo66.valiutchik.domain.entities.BestCurrencyRate
-import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Clock
 
 class CurrencyRatesInteractorImpl @Inject constructor(
   private val refreshExchangeRates: RefreshExchangeRates,
@@ -29,22 +29,22 @@ class CurrencyRatesInteractorImpl @Inject constructor(
   private val loadExchangeRates: LoadExchangeRates,
 ) : CurrencyRatesInteractor {
   override suspend fun refreshExchangeRates() =
-    refreshExchangeRates.execute(LocalDateTime.now())
+    refreshExchangeRates.execute(Clock.System.now())
 
   override suspend fun forceRefreshExchangeRates() =
-    forceRefreshExchangeRates.execute(LocalDateTime.now())
+    forceRefreshExchangeRates.execute(Clock.System.now())
 
   override suspend fun refreshExchangeRatesForDefaultCity() =
     refreshExchangeRatesForDefaultCity.execute(
-      LocalDateTime.now()
+      Clock.System.now()
     )
 
   override suspend fun forceRefreshExchangeRatesForDefaultCity() =
     forceRefreshExchangeRatesForDefaultCity.execute(
-      LocalDateTime.now()
+      Clock.System.now()
     )
 
   override fun loadExchangeRates(): Flow<List<BestCurrencyRate>> = loadExchangeRates.execute(
-    LocalDateTime.now()
+    Clock.System.now()
   )
 }

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRates.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRates.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package fobo66.valiutchik.domain.usecases
 
-import java.time.LocalDateTime
+import kotlinx.datetime.Instant
 
 interface ForceRefreshExchangeRates {
-  suspend fun execute(now: LocalDateTime)
+  suspend fun execute(now: Instant)
 }

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRatesForDefaultCity.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRatesForDefaultCity.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package fobo66.valiutchik.domain.usecases
 
-import java.time.LocalDateTime
+import kotlinx.datetime.Instant
 
 interface ForceRefreshExchangeRatesForDefaultCity {
-  suspend fun execute(now: LocalDateTime)
+  suspend fun execute(now: Instant)
 }

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRatesForDefaultCityImpl.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRatesForDefaultCityImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@ package fobo66.valiutchik.domain.usecases
 import fobo66.valiutchik.core.model.repository.CurrencyRateRepository
 import fobo66.valiutchik.core.model.repository.CurrencyRatesTimestampRepository
 import fobo66.valiutchik.core.model.repository.PreferenceRepository
-import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Instant
 
 class ForceRefreshExchangeRatesForDefaultCityImpl @Inject constructor(
   private val timestampRepository: CurrencyRatesTimestampRepository,
   private val currencyRateRepository: CurrencyRateRepository,
   private val preferenceRepository: PreferenceRepository
 ) : ForceRefreshExchangeRatesForDefaultCity {
-  override suspend fun execute(now: LocalDateTime) {
+  override suspend fun execute(now: Instant) {
     val defaultCity = preferenceRepository.observeDefaultCityPreference().first()
     currencyRateRepository.refreshExchangeRates(defaultCity, now)
     timestampRepository.saveTimestamp(now)

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRatesImpl.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRatesImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ import fobo66.valiutchik.core.model.repository.CurrencyRateRepository
 import fobo66.valiutchik.core.model.repository.CurrencyRatesTimestampRepository
 import fobo66.valiutchik.core.model.repository.LocationRepository
 import fobo66.valiutchik.core.model.repository.PreferenceRepository
-import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Instant
 
 class ForceRefreshExchangeRatesImpl @Inject constructor(
   private val locationRepository: LocationRepository,
@@ -30,7 +30,7 @@ class ForceRefreshExchangeRatesImpl @Inject constructor(
   private val currencyRateRepository: CurrencyRateRepository,
   private val preferenceRepository: PreferenceRepository
 ) : ForceRefreshExchangeRates {
-  override suspend fun execute(now: LocalDateTime) {
+  override suspend fun execute(now: Instant) {
     val defaultCity = preferenceRepository.observeDefaultCityPreference().first()
     val city = locationRepository.resolveUserCity(defaultCity)
 

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/LoadExchangeRates.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/LoadExchangeRates.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 package fobo66.valiutchik.domain.usecases
 
 import fobo66.valiutchik.domain.entities.BestCurrencyRate
-import java.time.LocalDateTime
 import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Instant
 
 interface LoadExchangeRates {
-  fun execute(now: LocalDateTime): Flow<List<BestCurrencyRate>>
+  fun execute(now: Instant): Flow<List<BestCurrencyRate>>
 }

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/LoadExchangeRatesImpl.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/LoadExchangeRatesImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -33,20 +33,20 @@ import fobo66.valiutchik.core.util.UAH
 import fobo66.valiutchik.core.util.USD
 import fobo66.valiutchik.domain.R
 import fobo66.valiutchik.domain.entities.BestCurrencyRate
-import java.time.LocalDateTime
 import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.datetime.Instant
 
 class LoadExchangeRatesImpl @Inject constructor(
   private val currencyRateRepository: CurrencyRateRepository,
   private val currencyRatesTimestampRepository: CurrencyRatesTimestampRepository
 ) : LoadExchangeRates {
   @OptIn(ExperimentalCoroutinesApi::class)
-  override fun execute(now: LocalDateTime): Flow<List<BestCurrencyRate>> =
+  override fun execute(now: Instant): Flow<List<BestCurrencyRate>> =
     currencyRatesTimestampRepository.loadLatestTimestamp(now)
       .flatMapLatest { currencyRateRepository.loadExchangeRates(it) }
       .map {

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRates.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRates.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package fobo66.valiutchik.domain.usecases
 
-import java.time.LocalDateTime
+import kotlinx.datetime.Instant
 
 interface RefreshExchangeRates {
-  suspend fun execute(now: LocalDateTime)
+  suspend fun execute(now: Instant)
 }

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRatesForDefaultCity.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRatesForDefaultCity.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package fobo66.valiutchik.domain.usecases
 
-import java.time.LocalDateTime
+import kotlinx.datetime.Instant
 
 interface RefreshExchangeRatesForDefaultCity {
-  suspend fun execute(now: LocalDateTime)
+  suspend fun execute(now: Instant)
 }

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRatesForDefaultCityImpl.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRatesForDefaultCityImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@ package fobo66.valiutchik.domain.usecases
 import fobo66.valiutchik.core.model.repository.CurrencyRateRepository
 import fobo66.valiutchik.core.model.repository.CurrencyRatesTimestampRepository
 import fobo66.valiutchik.core.model.repository.PreferenceRepository
-import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Instant
 
 class RefreshExchangeRatesForDefaultCityImpl @Inject constructor(
   private val timestampRepository: CurrencyRatesTimestampRepository,
   private val currencyRateRepository: CurrencyRateRepository,
   private val preferenceRepository: PreferenceRepository
 ) : RefreshExchangeRatesForDefaultCity {
-  override suspend fun execute(now: LocalDateTime) {
+  override suspend fun execute(now: Instant) {
     val defaultCity = preferenceRepository.observeDefaultCityPreference().first()
     val updateInterval = preferenceRepository.observeUpdateIntervalPreference().first()
     if (timestampRepository.isNeededToUpdateCurrencyRates(now, updateInterval)) {

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRatesImpl.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRatesImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ import fobo66.valiutchik.core.model.repository.CurrencyRateRepository
 import fobo66.valiutchik.core.model.repository.CurrencyRatesTimestampRepository
 import fobo66.valiutchik.core.model.repository.LocationRepository
 import fobo66.valiutchik.core.model.repository.PreferenceRepository
-import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Instant
 
 class RefreshExchangeRatesImpl @Inject constructor(
   private val locationRepository: LocationRepository,
@@ -30,7 +30,7 @@ class RefreshExchangeRatesImpl @Inject constructor(
   private val currencyRateRepository: CurrencyRateRepository,
   private val preferenceRepository: PreferenceRepository
 ) : RefreshExchangeRates {
-  override suspend fun execute(now: LocalDateTime) {
+  override suspend fun execute(now: Instant) {
     val defaultCity = preferenceRepository.observeDefaultCityPreference().first()
     val updateInterval = preferenceRepository.observeUpdateIntervalPreference().first()
     if (timestampRepository.isNeededToUpdateCurrencyRates(now, updateInterval)) {

--- a/domain/src/test/kotlin/fobo66/valiutchik/domain/fake/FakeCurrencyRateRepository.kt
+++ b/domain/src/test/kotlin/fobo66/valiutchik/domain/fake/FakeCurrencyRateRepository.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,17 +18,17 @@ package fobo66.valiutchik.domain.fake
 
 import fobo66.valiutchik.core.entities.BestCourse
 import fobo66.valiutchik.core.model.repository.CurrencyRateRepository
-import java.time.LocalDateTime
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.Instant
 
 class FakeCurrencyRateRepository : CurrencyRateRepository {
   var isRefreshed = false
 
-  override suspend fun refreshExchangeRates(city: String, now: LocalDateTime) {
+  override suspend fun refreshExchangeRates(city: String, now: Instant) {
     isRefreshed = true
   }
 
-  override fun loadExchangeRates(latestTimestamp: LocalDateTime): Flow<List<BestCourse>> =
+  override fun loadExchangeRates(latestTimestamp: Instant): Flow<List<BestCourse>> =
     flowOf(emptyList())
 }

--- a/domain/src/test/kotlin/fobo66/valiutchik/domain/fake/FakeCurrencyRatesTimestampRepository.kt
+++ b/domain/src/test/kotlin/fobo66/valiutchik/domain/fake/FakeCurrencyRatesTimestampRepository.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,24 +17,24 @@
 package fobo66.valiutchik.domain.fake
 
 import fobo66.valiutchik.core.model.repository.CurrencyRatesTimestampRepository
-import java.time.LocalDateTime
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.Instant
 
 class FakeCurrencyRatesTimestampRepository : CurrencyRatesTimestampRepository {
   var isNeededToUpdateCurrencyRates = true
   var isSaveTimestampCalled = false
 
   override suspend fun isNeededToUpdateCurrencyRates(
-    now: LocalDateTime,
+    now: Instant,
     updateInterval: Float
   ): Boolean =
     isNeededToUpdateCurrencyRates
 
-  override suspend fun saveTimestamp(now: LocalDateTime) {
+  override suspend fun saveTimestamp(now: Instant) {
     isSaveTimestampCalled = true
   }
 
-  override fun loadLatestTimestamp(now: LocalDateTime): Flow<LocalDateTime> =
+  override fun loadLatestTimestamp(now: Instant): Flow<Instant> =
     flowOf(now)
 }

--- a/domain/src/test/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRatesForDefaultCityTest.kt
+++ b/domain/src/test/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRatesForDefaultCityTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package fobo66.valiutchik.domain.usecases
 import fobo66.valiutchik.domain.fake.FakeCurrencyRateRepository
 import fobo66.valiutchik.domain.fake.FakeCurrencyRatesTimestampRepository
 import fobo66.valiutchik.domain.fake.FakePreferenceRepository
-import java.time.LocalDateTime
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -29,7 +29,7 @@ class ForceRefreshExchangeRatesForDefaultCityTest {
   private val currencyRateRepository = FakeCurrencyRateRepository()
   private val preferenceRepository = FakePreferenceRepository()
 
-  private val now = LocalDateTime.now()
+  private val now = Clock.System.now()
 
   private val refreshExchangeRates: ForceRefreshExchangeRatesForDefaultCity =
     ForceRefreshExchangeRatesForDefaultCityImpl(

--- a/domain/src/test/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRatesTest.kt
+++ b/domain/src/test/kotlin/fobo66/valiutchik/domain/usecases/ForceRefreshExchangeRatesTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2023 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import fobo66.valiutchik.domain.fake.FakeCurrencyRateRepository
 import fobo66.valiutchik.domain.fake.FakeCurrencyRatesTimestampRepository
 import fobo66.valiutchik.domain.fake.FakeLocationRepository
 import fobo66.valiutchik.domain.fake.FakePreferenceRepository
-import java.time.LocalDateTime
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -31,7 +31,7 @@ class ForceRefreshExchangeRatesTest {
   private val currencyRateRepository = FakeCurrencyRateRepository()
   private val preferenceRepository = FakePreferenceRepository()
 
-  private val now = LocalDateTime.now()
+  private val now = Clock.System.now()
 
   private val refreshExchangeRates: ForceRefreshExchangeRates =
     ForceRefreshExchangeRatesImpl(

--- a/domain/src/test/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRatesForDefaultCityTest.kt
+++ b/domain/src/test/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRatesForDefaultCityTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package fobo66.valiutchik.domain.usecases
 import fobo66.valiutchik.domain.fake.FakeCurrencyRateRepository
 import fobo66.valiutchik.domain.fake.FakeCurrencyRatesTimestampRepository
 import fobo66.valiutchik.domain.fake.FakePreferenceRepository
-import java.time.LocalDateTime
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -30,7 +30,7 @@ class RefreshExchangeRatesForDefaultCityTest {
   private val currencyRateRepository = FakeCurrencyRateRepository()
   private val preferenceRepository = FakePreferenceRepository()
 
-  private val now = LocalDateTime.now()
+  private val now = Clock.System.now()
 
   private val refreshExchangeRates: RefreshExchangeRatesForDefaultCity =
     RefreshExchangeRatesForDefaultCityImpl(

--- a/domain/src/test/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRatesTest.kt
+++ b/domain/src/test/kotlin/fobo66/valiutchik/domain/usecases/RefreshExchangeRatesTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2024 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import fobo66.valiutchik.domain.fake.FakeCurrencyRateRepository
 import fobo66.valiutchik.domain.fake.FakeCurrencyRatesTimestampRepository
 import fobo66.valiutchik.domain.fake.FakeLocationRepository
 import fobo66.valiutchik.domain.fake.FakePreferenceRepository
-import java.time.LocalDateTime
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -32,7 +32,7 @@ class RefreshExchangeRatesTest {
   private val currencyRateRepository = FakeCurrencyRateRepository()
   private val preferenceRepository = FakePreferenceRepository()
 
-  private val now = LocalDateTime.now()
+  private val now = Clock.System.now()
 
   private val refreshExchangeRates: RefreshExchangeRates =
     RefreshExchangeRatesImpl(


### PR DESCRIPTION
Improve multiplatform compatibility by switching from `java.time` to `kotlinx.datetime`. It's kind of the same now, but just in case I will ever consider migrating to multiplatform, app will be a little more ready for it