### PR TITLE
Switch to multiplatform URI

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
   ksp(libs.room.compiler)
   implementation(libs.androidx.datastore)
   implementation(libs.napier)
+  implementation(libs.uri)
 
   detektPlugins(libs.detekt.rules.formatting)
   detektPlugins(libs.detekt.rules.compose)

--- a/data/src/androidTest/kotlin/fobo66/valiutchik/core/fake/FakeIntentDataSource.kt
+++ b/data/src/androidTest/kotlin/fobo66/valiutchik/core/fake/FakeIntentDataSource.kt
@@ -18,7 +18,6 @@ package fobo66.valiutchik.core.fake
 
 import android.content.ComponentName
 import android.content.Intent
-import androidx.test.platform.app.InstrumentationRegistry
 import com.eygraber.uri.Uri
 import fobo66.valiutchik.core.model.datasource.IntentDataSource
 

--- a/data/src/androidTest/kotlin/fobo66/valiutchik/core/fake/FakeIntentDataSource.kt
+++ b/data/src/androidTest/kotlin/fobo66/valiutchik/core/fake/FakeIntentDataSource.kt
@@ -1,0 +1,39 @@
+/*
+ *    Copyright 2025 Andrey Mukamolov
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package fobo66.valiutchik.core.fake
+
+import android.content.ComponentName
+import android.content.Intent
+import androidx.test.platform.app.InstrumentationRegistry
+import com.eygraber.uri.Uri
+import fobo66.valiutchik.core.model.datasource.IntentDataSource
+
+class FakeIntentDataSource(private val componentName: ComponentName) : IntentDataSource {
+  var canResolveIntent = true
+
+  override fun createIntent(
+    uri: Uri,
+    action: String,
+  ): Intent = Intent()
+
+  override fun resolveIntent(intent: Intent): ComponentName? =
+    if (canResolveIntent) {
+      componentName
+    } else {
+      null
+    }
+}

--- a/data/src/androidTest/kotlin/fobo66/valiutchik/core/fake/FakeUriDataSource.kt
+++ b/data/src/androidTest/kotlin/fobo66/valiutchik/core/fake/FakeUriDataSource.kt
@@ -1,0 +1,29 @@
+/*
+ *    Copyright 2025 Andrey Mukamolov
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package fobo66.valiutchik.core.fake
+
+import com.eygraber.uri.Uri
+import fobo66.valiutchik.core.model.datasource.UriDataSource
+
+class FakeUriDataSource : UriDataSource {
+  override fun prepareUri(
+    scheme: String,
+    authority: String,
+    queryParameterKey: String,
+    queryParameterValue: String
+  ): Uri = Uri.EMPTY
+}

--- a/data/src/androidTest/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSourceTest.kt
+++ b/data/src/androidTest/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSourceTest.kt
@@ -17,10 +17,10 @@
 package fobo66.valiutchik.core.model.datasource
 
 import android.content.Intent
-import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.rule.IntentsRule
 import androidx.test.filters.SmallTest
+import com.eygraber.uri.Uri
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test

--- a/data/src/androidTest/kotlin/fobo66/valiutchik/core/model/repository/MapRepositoryImplTest.kt
+++ b/data/src/androidTest/kotlin/fobo66/valiutchik/core/model/repository/MapRepositoryImplTest.kt
@@ -16,13 +16,10 @@
 
 package fobo66.valiutchik.core.model.repository
 
-import android.content.ComponentName
-import android.content.Intent
-import android.net.Uri
 import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
-import fobo66.valiutchik.core.model.datasource.IntentDataSource
-import fobo66.valiutchik.core.model.datasource.UriDataSource
+import fobo66.valiutchik.core.fake.FakeIntentDataSource
+import fobo66.valiutchik.core.fake.FakeUriDataSource
 import org.junit.After
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -31,32 +28,9 @@ import org.junit.Test
 
 @SmallTest
 class MapRepositoryImplTest {
-  private val uriDataSource =
-    object : UriDataSource {
-      override fun prepareUri(
-        scheme: String,
-        authority: String,
-        queryParameterKey: String,
-        queryParameterValue: String,
-      ): Uri = Uri.EMPTY
-    }
-
+  private val uriDataSource = FakeUriDataSource()
   private val intentDataSource =
-    object : IntentDataSource {
-      var canResolveIntent = true
-
-      override fun createIntent(
-        uri: Uri,
-        action: String,
-      ): Intent = Intent()
-
-      override fun resolveIntent(intent: Intent): ComponentName? =
-        if (canResolveIntent) {
-          InstrumentationRegistry.getInstrumentation().componentName
-        } else {
-          null
-        }
-    }
+    FakeIntentDataSource(InstrumentationRegistry.getInstrumentation().componentName)
 
   private lateinit var mapRepository: MapRepository
 

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSource.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSource.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2025 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package fobo66.valiutchik.core.model.datasource
 
 import android.content.ComponentName
 import android.content.Intent
-import android.net.Uri
+import com.eygraber.uri.Uri
 
 /**
  * Datasource for working with the Intents

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSourceImpl.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSourceImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2024 Andrey Mukamolov
+ *    Copyright 2025 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,12 +19,13 @@ package fobo66.valiutchik.core.model.datasource
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
+import com.eygraber.uri.Uri
+import com.eygraber.uri.toAndroidUri
 
 class IntentDataSourceImpl(
   private val context: Context
 ) : IntentDataSource {
-  override fun createIntent(uri: Uri, action: String): Intent = Intent(action, uri)
+  override fun createIntent(uri: Uri, action: String): Intent = Intent(action, uri.toAndroidUri())
 
   override fun resolveIntent(intent: Intent): ComponentName? =
     intent.resolveActivity(context.packageManager)

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/UriDataSource.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/UriDataSource.kt
@@ -18,7 +18,6 @@ package fobo66.valiutchik.core.model.datasource
 
 import com.eygraber.uri.Uri
 
-
 /**
  * Datasource tp deal with URIs
  */

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/UriDataSource.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/UriDataSource.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2025 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 
 package fobo66.valiutchik.core.model.datasource
 
-import android.net.Uri
+import com.eygraber.uri.Uri
+
 
 /**
  * Datasource tp deal with URIs

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/UriDataSourceImpl.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/UriDataSourceImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2024 Andrey Mukamolov
+ *    Copyright 2025 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package fobo66.valiutchik.core.model.datasource
 
-import android.net.Uri
+import com.eygraber.uri.Uri
 
 class UriDataSourceImpl : UriDataSource {
   override fun prepareUri(

--- a/data/src/test/kotlin/fobo66/valiutchik/core/model/datasource/UriDataSourceTest.kt
+++ b/data/src/test/kotlin/fobo66/valiutchik/core/model/datasource/UriDataSourceTest.kt
@@ -16,7 +16,7 @@
 
 package fobo66.valiutchik.core.model.datasource
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import fobo66.valiutchik.core.model.repository.URI_AUTHORITY
 import fobo66.valiutchik.core.model.repository.URI_PARAM_KEY
 import fobo66.valiutchik.core.model.repository.URI_SCHEME
@@ -26,7 +26,7 @@ class UriDataSourceTest {
   private val uriDataSource: UriDataSource = UriDataSourceImpl()
 
   @Test
-  fun prepareHttpUri() {
+  fun `prepare HTTP URI`() {
     val uri =
       uriDataSource.prepareUri(
         "https",
@@ -35,11 +35,11 @@ class UriDataSourceTest {
         "value",
       )
 
-    Truth.assertThat(uri.toString()).isEqualTo("https://example.com?key=value")
+    assertThat(uri.toString()).isEqualTo("https://example.com?key=value")
   }
 
   @Test
-  fun prepareMapUri() {
+  fun `prepare map URI`() {
     val uri =
       uriDataSource.prepareUri(
         URI_SCHEME,
@@ -48,6 +48,6 @@ class UriDataSourceTest {
         "test",
       )
 
-    Truth.assertThat(uri.getQueryParameter(URI_PARAM_KEY)).isEqualTo("test")
+    assertThat(uri.getQueryParameter(URI_PARAM_KEY)).isEqualTo("test")
   }
 }

--- a/data/src/test/kotlin/fobo66/valiutchik/core/model/datasource/UriDataSourceTest.kt
+++ b/data/src/test/kotlin/fobo66/valiutchik/core/model/datasource/UriDataSourceTest.kt
@@ -16,14 +16,12 @@
 
 package fobo66.valiutchik.core.model.datasource
 
-import androidx.test.filters.SmallTest
-import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth
 import fobo66.valiutchik.core.model.repository.URI_AUTHORITY
 import fobo66.valiutchik.core.model.repository.URI_PARAM_KEY
 import fobo66.valiutchik.core.model.repository.URI_SCHEME
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-@SmallTest
 class UriDataSourceTest {
   private val uriDataSource: UriDataSource = UriDataSourceImpl()
 
@@ -37,7 +35,7 @@ class UriDataSourceTest {
         "value",
       )
 
-    assertThat(uri.toString()).isEqualTo("https://example.com?key=value")
+    Truth.assertThat(uri.toString()).isEqualTo("https://example.com?key=value")
   }
 
   @Test
@@ -50,6 +48,6 @@ class UriDataSourceTest {
         "test",
       )
 
-    assertThat(uri.getQueryParameter(URI_PARAM_KEY)).isEqualTo("test")
+    Truth.assertThat(uri.getQueryParameter(URI_PARAM_KEY)).isEqualTo("test")
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ profileinstallerVersion = "1.4.1"
 room = "2.7.1"
 truth = "1.4.4"
 turbine = "1.2.0"
+uri = "0.0.19"
 work = "2.10.1"
 
 [libraries]
@@ -122,6 +123,7 @@ room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "
 room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+uri = { module = "com.eygraber:uri-kmp", version.ref = "uri" }
 work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 work-testing = { group = "androidx.work", name = "work-testing", version.ref = "work" }
 


### PR DESCRIPTION
Use [multiplatform library](https://github.com/eygraber/uri-kmp) instead of `android.net.Uri` for easier possible switch to multiplatform in the future