### PR TITLE
Return non-Android classes for map intent

### DIFF
--- a/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/Navigation.kt
+++ b/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/Navigation.kt
@@ -61,7 +61,7 @@ fun BestRatesScreenDestination(
   manualRefreshVisible: Boolean,
   canOpenSettings: Boolean,
   modifier: Modifier = Modifier,
-  mainViewModel: MainViewModel = koinViewModel()
+  mainViewModel: MainViewModel = koinViewModel(),
 ) {
   val context = LocalContext.current
   val mapLauncher =
@@ -99,7 +99,7 @@ fun BestRatesScreenDestination(
       val mapIntent = mainViewModel.findBankOnMap(bankName)
       if (mapIntent != null) {
         mapLauncher.launch(
-          Intent.createChooser(mapIntent, context.getString(string.open_map))
+          Intent.createChooser(Intent.parseUri(mapIntent, 0), context.getString(string.open_map)),
         )
       } else {
         scope.launch {
@@ -122,18 +122,18 @@ fun BestRatesScreenDestination(
     },
     isRefreshing = viewState is MainScreenState.Loading,
     onRefresh = mainViewModel::manualRefresh,
-    modifier = modifier
+    modifier = modifier,
   )
 }
 
 private suspend fun showSnackbar(
   snackbarHostState: SnackbarHostState,
   message: String,
-  duration: SnackbarDuration = Short
+  duration: SnackbarDuration = Short,
 ) {
   snackbarHostState.showSnackbar(
     message = message,
-    duration = duration
+    duration = duration,
   )
 }
 
@@ -143,7 +143,7 @@ fun PreferenceScreenDestination(
   navigator: ThreePaneScaffoldNavigator<Any>,
   canOpenSettings: Boolean,
   modifier: Modifier = Modifier,
-  preferencesViewModel: PreferencesViewModel = koinViewModel()
+  preferencesViewModel: PreferencesViewModel = koinViewModel(),
 ) {
   val scope = rememberCoroutineScope()
   val defaultCity by preferencesViewModel.defaultCityPreference
@@ -170,7 +170,7 @@ fun PreferenceScreenDestination(
         navigator.navigateBack()
       }
     },
-    modifier = modifier
+    modifier = modifier,
   )
 }
 
@@ -179,7 +179,7 @@ fun PreferenceScreenDestination(
 fun OpenSourceLicensesDestination(
   navigator: ThreePaneScaffoldNavigator<Any>,
   modifier: Modifier = Modifier,
-  viewModel: OpenSourceLicensesViewModel = koinViewModel()
+  viewModel: OpenSourceLicensesViewModel = koinViewModel(),
 ) {
   val uriHandler = LocalUriHandler.current
   val scope = rememberCoroutineScope()
@@ -194,6 +194,6 @@ fun OpenSourceLicensesDestination(
         navigator.navigateBack()
       }
     },
-    modifier = modifier
+    modifier = modifier,
   )
 }

--- a/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/main/MainViewModel.kt
+++ b/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/main/MainViewModel.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2024 Andrey Mukamolov
+ *    Copyright 2025 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package fobo66.exchangecourcesbelarus.ui.main
 
-import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.Constraints
@@ -33,7 +32,6 @@ import fobo66.exchangecourcesbelarus.work.WORKER_ARG_LOCATION_AVAILABLE
 import fobo66.valiutchik.domain.usecases.CopyCurrencyRateToClipboard
 import fobo66.valiutchik.domain.usecases.CurrencyRatesInteractor
 import fobo66.valiutchik.domain.usecases.FindBankOnMap
-import java.util.concurrent.TimeUnit
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -47,6 +45,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.concurrent.TimeUnit
 
 private const val WORK_BACKGROUND_REFRESH = "backgroundRefresh"
 
@@ -54,89 +53,95 @@ class MainViewModel(
   currencyRatesInteractor: CurrencyRatesInteractor,
   private val copyCurrencyRateToClipboard: CopyCurrencyRateToClipboard,
   private val findBankOnMap: FindBankOnMap,
-  private val workManager: WorkManager
+  private val workManager: WorkManager,
 ) : ViewModel() {
-
-  val bestCurrencyRates = currencyRatesInteractor.loadExchangeRates()
-    .onEach {
-      if (it.isEmpty()) {
-        isRefreshTriggered.emit(true)
-      }
-    }
-    .map { it.toImmutableList() }
-    .stateIn(
-      scope = viewModelScope,
-      started = SharingStarted.WhileSubscribed(STATE_FLOW_SUBSCRIBE_STOP_TIMEOUT_MS),
-      initialValue = persistentListOf()
-    )
+  val bestCurrencyRates =
+    currencyRatesInteractor
+      .loadExchangeRates()
+      .onEach {
+        if (it.isEmpty()) {
+          isRefreshTriggered.emit(true)
+        }
+      }.map { it.toImmutableList() }
+      .stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(STATE_FLOW_SUBSCRIBE_STOP_TIMEOUT_MS),
+        initialValue = persistentListOf(),
+      )
 
   private val isLocationPermissionGranted: MutableStateFlow<Boolean?> = MutableStateFlow(null)
   private val isRefreshTriggered = MutableStateFlow(false)
 
   @OptIn(ExperimentalCoroutinesApi::class)
-  val screenState = combine(
-    isRefreshTriggered,
-    isLocationPermissionGranted,
-    currencyRatesInteractor.loadUpdateInterval(),
-    ::MainScreenStateTrigger
-  )
-    .filter { it.isRefreshTriggered && it.isLocationAvailable != null }
-    .onEach {
-      handleRefresh(it.isLocationAvailable == true, it.updateInterval)
-      isRefreshTriggered.emit(false)
-    }
-    .flatMapLatest { workManager.getWorkInfosForUniqueWorkFlow(WORK_BACKGROUND_REFRESH) }
-    .map { infos ->
-      infos.any { info ->
-        info.state == WorkInfo.State.RUNNING
-      }
-    }
-    .map {
-      if (it) {
-        MainScreenState.Loading
-      } else {
-        MainScreenState.LoadedRates
-      }
-    }
-    .stateIn(
-      viewModelScope,
-      SharingStarted.WhileSubscribed(STATE_FLOW_SUBSCRIBE_STOP_TIMEOUT_MS),
-      initialValue = MainScreenState.Initial
-    )
-
-  fun findBankOnMap(bankName: CharSequence): Intent? = findBankOnMap.execute(bankName)
-
-  fun handleRefresh(isLocationAvailable: Boolean, updateInterval: Long) = viewModelScope.launch {
-    val workRequest = PeriodicWorkRequestBuilder<RatesRefreshWorker>(updateInterval, TimeUnit.HOURS)
-      .setConstraints(
-        Constraints.Builder()
-          .setRequiresBatteryNotLow(true)
-          .setRequiredNetworkType(NetworkType.NOT_ROAMING)
-          .build()
+  val screenState =
+    combine(
+      isRefreshTriggered,
+      isLocationPermissionGranted,
+      currencyRatesInteractor.loadUpdateInterval(),
+      ::MainScreenStateTrigger,
+    ).filter { it.isRefreshTriggered && it.isLocationAvailable != null }
+      .onEach {
+        handleRefresh(it.isLocationAvailable == true, it.updateInterval)
+        isRefreshTriggered.emit(false)
+      }.flatMapLatest { workManager.getWorkInfosForUniqueWorkFlow(WORK_BACKGROUND_REFRESH) }
+      .map { infos ->
+        infos.any { info ->
+          info.state == WorkInfo.State.RUNNING
+        }
+      }.map {
+        if (it) {
+          MainScreenState.Loading
+        } else {
+          MainScreenState.LoadedRates
+        }
+      }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(STATE_FLOW_SUBSCRIBE_STOP_TIMEOUT_MS),
+        initialValue = MainScreenState.Initial,
       )
-      .setInputData(workDataOf(WORKER_ARG_LOCATION_AVAILABLE to isLocationAvailable))
-      .build()
+
+  fun findBankOnMap(bankName: CharSequence): String? = findBankOnMap.execute(bankName)
+
+  fun handleRefresh(
+    isLocationAvailable: Boolean,
+    updateInterval: Long,
+  ) = viewModelScope.launch {
+    val workRequest =
+      PeriodicWorkRequestBuilder<RatesRefreshWorker>(updateInterval, TimeUnit.HOURS)
+        .setConstraints(
+          Constraints
+            .Builder()
+            .setRequiresBatteryNotLow(true)
+            .setRequiredNetworkType(NetworkType.NOT_ROAMING)
+            .build(),
+        ).setInputData(workDataOf(WORKER_ARG_LOCATION_AVAILABLE to isLocationAvailable))
+        .build()
     workManager.enqueueUniquePeriodicWork(
       WORK_BACKGROUND_REFRESH,
       ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
-      workRequest
+      workRequest,
     )
   }
 
-  fun manualRefresh() = viewModelScope.launch {
-    isRefreshTriggered.emit(true)
-  }
-
-  fun handleLocationPermission(permissionGranted: Boolean) = viewModelScope.launch {
-    isLocationPermissionGranted.update {
-      if (it != permissionGranted) {
-        isRefreshTriggered.emit(true)
-      }
-      permissionGranted
+  fun manualRefresh() =
+    viewModelScope.launch {
+      isRefreshTriggered.emit(true)
     }
-  }
 
-  fun copyCurrencyRateToClipboard(currencyName: CharSequence, currencyValue: CharSequence) {
+  fun handleLocationPermission(permissionGranted: Boolean) =
+    viewModelScope.launch {
+      isLocationPermissionGranted.update {
+        if (it != permissionGranted) {
+          isRefreshTriggered.emit(true)
+        }
+        permissionGranted
+      }
+    }
+
+  fun copyCurrencyRateToClipboard(
+    currencyName: CharSequence,
+    currencyValue: CharSequence,
+  ) {
     copyCurrencyRateToClipboard.execute(currencyName, currencyValue)
   }
 }

--- a/data/src/androidTest/kotlin/fobo66/valiutchik/core/fake/FakeIntentDataSource.kt
+++ b/data/src/androidTest/kotlin/fobo66/valiutchik/core/fake/FakeIntentDataSource.kt
@@ -16,23 +16,16 @@
 
 package fobo66.valiutchik.core.fake
 
-import android.content.ComponentName
-import android.content.Intent
 import com.eygraber.uri.Uri
 import fobo66.valiutchik.core.model.datasource.IntentDataSource
 
-class FakeIntentDataSource(private val componentName: ComponentName) : IntentDataSource {
+class FakeIntentDataSource : IntentDataSource {
   var canResolveIntent = true
 
-  override fun createIntent(
+  override fun createIntentUri(
     uri: Uri,
     action: String,
-  ): Intent = Intent()
+  ): String = Uri.EMPTY.toString()
 
-  override fun resolveIntent(intent: Intent): ComponentName? =
-    if (canResolveIntent) {
-      componentName
-    } else {
-      null
-    }
+  override fun checkIntentUri(uri: String): Boolean = canResolveIntent
 }

--- a/data/src/androidTest/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSourceTest.kt
+++ b/data/src/androidTest/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSourceTest.kt
@@ -38,19 +38,19 @@ class IntentDataSourceTest {
 
   @Test
   fun createIntent() {
-    val intent = intentDataSource.createIntent(Uri.EMPTY)
+    val intent = Intent.parseUri(intentDataSource.createIntentUri(Uri.EMPTY), 0)
     assertIntent(intent).hasAction(Intent.ACTION_VIEW)
   }
 
   @Test
   fun canResolveIntent() {
-    val intent = intentDataSource.createIntent(uri)
-    assertThat(intentDataSource.resolveIntent(intent)).isNotNull()
+    val intent = intentDataSource.createIntentUri(uri)
+    assertThat(intentDataSource.checkIntentUri(intent)).isTrue()
   }
 
   @Test
   fun cannotResolveEmptyIntent() {
-    val intent = intentDataSource.createIntent(Uri.EMPTY)
-    assertThat(intentDataSource.resolveIntent(intent)).isNull()
+    val intent = intentDataSource.createIntentUri(Uri.EMPTY)
+    assertThat(intentDataSource.checkIntentUri(intent)).isFalse()
   }
 }

--- a/data/src/androidTest/kotlin/fobo66/valiutchik/core/model/repository/MapRepositoryImplTest.kt
+++ b/data/src/androidTest/kotlin/fobo66/valiutchik/core/model/repository/MapRepositoryImplTest.kt
@@ -17,7 +17,6 @@
 package fobo66.valiutchik.core.model.repository
 
 import androidx.test.filters.SmallTest
-import androidx.test.platform.app.InstrumentationRegistry
 import fobo66.valiutchik.core.fake.FakeIntentDataSource
 import fobo66.valiutchik.core.fake.FakeUriDataSource
 import org.junit.After
@@ -30,7 +29,7 @@ import org.junit.Test
 class MapRepositoryImplTest {
   private val uriDataSource = FakeUriDataSource()
   private val intentDataSource =
-    FakeIntentDataSource(InstrumentationRegistry.getInstrumentation().componentName)
+    FakeIntentDataSource()
 
   private lateinit var mapRepository: MapRepository
 

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSource.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSource.kt
@@ -16,7 +16,6 @@
 
 package fobo66.valiutchik.core.model.datasource
 
-import android.content.ComponentName
 import android.content.Intent
 import com.eygraber.uri.Uri
 
@@ -27,12 +26,15 @@ interface IntentDataSource {
   /**
    * Create new Intent
    */
-  fun createIntent(uri: Uri, action: String = Intent.ACTION_VIEW): Intent
+  fun createIntentUri(
+    uri: Uri,
+    action: String = Intent.ACTION_VIEW,
+  ): String
 
   /**
    * Check if the given Intent can be resolved by the system
    *
    * @return null if there's no handler
    */
-  fun resolveIntent(intent: Intent): ComponentName?
+  fun checkIntentUri(uri: String): Boolean
 }

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSourceImpl.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/datasource/IntentDataSourceImpl.kt
@@ -16,17 +16,19 @@
 
 package fobo66.valiutchik.core.model.datasource
 
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import com.eygraber.uri.Uri
 import com.eygraber.uri.toAndroidUri
 
 class IntentDataSourceImpl(
-  private val context: Context
+  private val context: Context,
 ) : IntentDataSource {
-  override fun createIntent(uri: Uri, action: String): Intent = Intent(action, uri.toAndroidUri())
+  override fun createIntentUri(
+    uri: Uri,
+    action: String,
+  ): String = Intent(action, uri.toAndroidUri()).toUri(0)
 
-  override fun resolveIntent(intent: Intent): ComponentName? =
-    intent.resolveActivity(context.packageManager)
+  override fun checkIntentUri(uri: String): Boolean =
+    Intent.parseUri(uri, 0).resolveActivity(context.packageManager) != null
 }

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/repository/MapRepository.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/repository/MapRepository.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2025 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,9 @@
 
 package fobo66.valiutchik.core.model.repository
 
-import android.content.Intent
-
 /**
  * Repository to open map
  */
 interface MapRepository {
-  fun searchOnMap(query: CharSequence): Intent?
+  fun searchOnMap(query: CharSequence): String?
 }

--- a/data/src/main/kotlin/fobo66/valiutchik/core/model/repository/MapRepositoryImpl.kt
+++ b/data/src/main/kotlin/fobo66/valiutchik/core/model/repository/MapRepositoryImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2024 Andrey Mukamolov
+ *    Copyright 2025 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package fobo66.valiutchik.core.model.repository
 
-import android.content.Intent
 import fobo66.valiutchik.core.model.datasource.IntentDataSource
 import fobo66.valiutchik.core.model.datasource.UriDataSource
 import io.github.aakira.napier.Napier
@@ -27,18 +26,19 @@ const val URI_PARAM_KEY = "q"
 
 class MapRepositoryImpl(
   private val uriDataSource: UriDataSource,
-  private val intentDataSource: IntentDataSource
+  private val intentDataSource: IntentDataSource,
 ) : MapRepository {
-  override fun searchOnMap(query: CharSequence): Intent? {
-    val mapUri = uriDataSource.prepareUri(
-      URI_SCHEME,
-      URI_AUTHORITY,
-      URI_PARAM_KEY,
-      query.toString()
-    )
-    val intent = intentDataSource.createIntent(mapUri)
+  override fun searchOnMap(query: CharSequence): String? {
+    val mapUri =
+      uriDataSource.prepareUri(
+        URI_SCHEME,
+        URI_AUTHORITY,
+        URI_PARAM_KEY,
+        query.toString(),
+      )
+    val intent = intentDataSource.createIntentUri(mapUri)
 
-    val canResolveIntent = intentDataSource.resolveIntent(intent) != null
+    val canResolveIntent = intentDataSource.checkIntentUri(intent)
 
     return if (canResolveIntent) {
       intent

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/FindBankOnMap.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/FindBankOnMap.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2022 Andrey Mukamolov
+ *    Copyright 2025 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package fobo66.valiutchik.domain.usecases
 
-import android.content.Intent
-
 interface FindBankOnMap {
-  fun execute(bankName: CharSequence): Intent?
+  fun execute(bankName: CharSequence): String?
 }

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/FindBankOnMapImpl.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/FindBankOnMapImpl.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2024 Andrey Mukamolov
+ *    Copyright 2025 Andrey Mukamolov
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,10 @@
 
 package fobo66.valiutchik.domain.usecases
 
-import android.content.Intent
 import fobo66.valiutchik.core.model.repository.MapRepository
 
 class FindBankOnMapImpl(
-  private val mapRepository: MapRepository
+  private val mapRepository: MapRepository,
 ) : FindBankOnMap {
-  override fun execute(bankName: CharSequence): Intent? = mapRepository.searchOnMap(bankName)
+  override fun execute(bankName: CharSequence): String? = mapRepository.searchOnMap(bankName)
 }


### PR DESCRIPTION
Make work with maps more multiplatform-friendly by avoiding direct references to Android classes in the data layer