### PR TITLE
Simplified clipboard handling

### DIFF
--- a/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/Navigation.kt
+++ b/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/Navigation.kt
@@ -97,8 +97,8 @@ fun BestRatesScreenDestination(
             val mapIntentUri = mainViewModel.findBankOnMap(bankName)
             openMap(mapIntentUri, context, scope, snackbarHostState)
         },
-        onBestRateLongClick = { currencyName, currencyValue ->
-            mainViewModel.copyCurrencyRateToClipboard(currencyName, currencyValue)
+        onBestRateLongClick = { currencyValue ->
+            mainViewModel.copyCurrencyRateToClipboard(currencyValue)
             scope.launch {
                 showSnackbar(snackbarHostState, context.getString(R.string.currency_value_copied))
             }

--- a/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/main/BestRatesList.kt
+++ b/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/main/BestRatesList.kt
@@ -74,7 +74,7 @@ import kotlinx.collections.immutable.persistentListOf
 fun BestRatesGrid(
     bestCurrencyRates: ImmutableList<BestCurrencyRate>,
     onBestRateClick: (String) -> Unit,
-    onBestRateLongClick: (String, String) -> Unit,
+    onBestRateLongClick: (String) -> Unit,
     onShareClick: (String, String) -> Unit,
     showExplicitRefresh: Boolean,
     showSettings: Boolean,
@@ -167,7 +167,7 @@ fun BestCurrencyRateCard(
     currencyValue: String,
     bankName: String,
     onClick: (String) -> Unit,
-    onLongClick: (String, String) -> Unit,
+    onLongClick: (String) -> Unit,
     onShareClick: (String, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -176,7 +176,7 @@ fun BestCurrencyRateCard(
         modifier
             .clip(CardDefaults.elevatedShape)
             .combinedClickable(
-                onLongClick = { onLongClick(currencyName, currencyValue) },
+                onLongClick = { onLongClick(currencyValue) },
                 onClick = { onClick(bankName) }
             )
     ) {
@@ -240,7 +240,7 @@ private fun BestCurrencyRatesPreview() {
                 )
             ),
             onBestRateClick = {},
-            onBestRateLongClick = { _, _ -> },
+            onBestRateLongClick = {},
             onShareClick = { _, _ -> },
             showExplicitRefresh = true,
             showSettings = true,

--- a/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/main/MainViewModel.kt
+++ b/app/src/main/kotlin/fobo66/exchangecourcesbelarus/ui/main/MainViewModel.kt
@@ -98,7 +98,7 @@ class MainViewModel(
         }
     }
 
-    fun copyCurrencyRateToClipboard(currencyName: CharSequence, currencyValue: CharSequence) {
-        copyCurrencyRateToClipboard.execute(currencyName, currencyValue)
+    fun copyCurrencyRateToClipboard(currencyValue: CharSequence) {
+        copyCurrencyRateToClipboard.execute(currencyValue)
     }
 }

--- a/data/src/androidMain/kotlin/fobo66/valiutchik/core/model/datasource/ClipboardDataSourceImpl.kt
+++ b/data/src/androidMain/kotlin/fobo66/valiutchik/core/model/datasource/ClipboardDataSourceImpl.kt
@@ -21,10 +21,12 @@ import android.content.ClipboardManager
 import android.content.Context
 import androidx.core.content.getSystemService
 
+private const val CLIP_LABEL = "CURRENCY_EXCHANGE_RATE"
+
 class ClipboardDataSourceImpl(private val context: Context) : ClipboardDataSource {
 
-    override fun copyToClipboard(label: CharSequence, value: CharSequence): Boolean {
-        val clipData = ClipData.newPlainText(label, value)
+    override fun copyToClipboard(value: CharSequence): Boolean {
+        val clipData = ClipData.newPlainText(CLIP_LABEL, value)
         val clipboardManager = context.getSystemService<ClipboardManager>()
         return clipboardManager?.let {
             it.setPrimaryClip(clipData)

--- a/data/src/commonMain/kotlin/fobo66/valiutchik/core/model/datasource/ClipboardDataSource.kt
+++ b/data/src/commonMain/kotlin/fobo66/valiutchik/core/model/datasource/ClipboardDataSource.kt
@@ -23,10 +23,9 @@ interface ClipboardDataSource {
     /**
      * Add provided entry to the device's clipboard
      *
-     * @param label Clipboard item label
      * @param value String value of the item
      *
      * @return Whether or not clipboard operation was successful
      */
-    fun copyToClipboard(label: CharSequence, value: CharSequence): Boolean
+    fun copyToClipboard(value: CharSequence): Boolean
 }

--- a/data/src/commonMain/kotlin/fobo66/valiutchik/core/model/repository/ClipboardRepository.kt
+++ b/data/src/commonMain/kotlin/fobo66/valiutchik/core/model/repository/ClipboardRepository.kt
@@ -24,5 +24,5 @@ interface ClipboardRepository {
     /**
      * Copy string to clipboard
      */
-    fun copyToClipboard(label: CharSequence, value: CharSequence)
+    fun copyToClipboard(value: CharSequence)
 }

--- a/data/src/commonMain/kotlin/fobo66/valiutchik/core/model/repository/ClipboardRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/fobo66/valiutchik/core/model/repository/ClipboardRepositoryImpl.kt
@@ -22,9 +22,9 @@ import io.github.aakira.napier.Napier
 class ClipboardRepositoryImpl(private val clipboardDataSource: ClipboardDataSource) :
     ClipboardRepository {
 
-    override fun copyToClipboard(label: CharSequence, value: CharSequence) {
-        Napier.v { "Copying to clipboard: label = $label, value = $value" }
-        if (clipboardDataSource.copyToClipboard(label, value)) {
+    override fun copyToClipboard(value: CharSequence) {
+        Napier.v { "Copying to clipboard: value = $value" }
+        if (clipboardDataSource.copyToClipboard(value)) {
             Napier.v("Copied successfully")
         } else {
             Napier.v("Copying failed")

--- a/data/src/jvmMain/kotlin/fobo66/valiutchik/core/model/datasource/ClipboardDataSourceJvmImpl.kt
+++ b/data/src/jvmMain/kotlin/fobo66/valiutchik/core/model/datasource/ClipboardDataSourceJvmImpl.kt
@@ -16,20 +16,17 @@
 
 package fobo66.valiutchik.core.model.datasource
 
-import io.github.aakira.napier.Napier
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
 
 class ClipboardDataSourceJvmImpl : ClipboardDataSource {
-    override fun copyToClipboard(label: CharSequence, value: CharSequence): Boolean {
+    override fun copyToClipboard(value: CharSequence): Boolean {
         Toolkit.getDefaultToolkit()
             .systemClipboard
             .setContents(
                 StringSelection(value.toString()),
                 null
             )
-
-        Napier.v { "Copied $label: $value" }
 
         return true
     }

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/CopyCurrencyRateToClipboard.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/CopyCurrencyRateToClipboard.kt
@@ -17,5 +17,5 @@
 package fobo66.valiutchik.domain.usecases
 
 interface CopyCurrencyRateToClipboard {
-    fun execute(currencyName: CharSequence, currencyValue: CharSequence)
+    fun execute(currencyValue: CharSequence)
 }

--- a/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/CopyCurrencyRateToClipboardImpl.kt
+++ b/domain/src/main/kotlin/fobo66/valiutchik/domain/usecases/CopyCurrencyRateToClipboardImpl.kt
@@ -20,7 +20,7 @@ import fobo66.valiutchik.core.model.repository.ClipboardRepository
 
 class CopyCurrencyRateToClipboardImpl(private val clipboardRepository: ClipboardRepository) :
     CopyCurrencyRateToClipboard {
-    override fun execute(currencyName: CharSequence, currencyValue: CharSequence) {
-        clipboardRepository.copyToClipboard(currencyName, currencyValue)
+    override fun execute(currencyValue: CharSequence) {
+        clipboardRepository.copyToClipboard(currencyValue)
     }
 }


### PR DESCRIPTION
Looks like the label of the clipboard is not visible on Android to the user, so we can use some constant. It's a good thing, because desktop doesn't have a label for the clipboard items, and we pass a localized string from UI all the way down just to end up not needing it in most cases, which is not ideal