### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,6 @@
 name: Android CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/fobo66/valiutchik-android/security/code-scanning/2](https://github.com/fobo66/valiutchik-android/security/code-scanning/2)

To fix the problem, add a `permissions` block at the top level of the workflow file, immediately after the `name` field and before the `on` field. This will apply the least privilege principle to all jobs in the workflow, restricting the `GITHUB_TOKEN` to only have read access to repository contents. No other changes are needed, as none of the jobs require additional permissions. The fix involves editing `.github/workflows/android.yml` to insert:

```yaml
permissions:
  contents: read
```

after the `name: Android CI` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
